### PR TITLE
Toasts no longer stop page changes and are now more readable!

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -16,6 +16,10 @@
     font-size: 20px;
 }
 
+.wizardToast {
+    text-align: center !important;
+  }
+
 @media screen and (min-width: 765px)  {
     .branchRadio .alert-wrapper{
         font-size: 30px;
@@ -29,6 +33,11 @@
     .alert-button{
         font-size: 25px!important;
     }
+
+    .wizardToast {
+        text-align: center !important;
+      }
+
 }
 
 

--- a/src/pages/dashboard/dashboard.ts
+++ b/src/pages/dashboard/dashboard.ts
@@ -35,14 +35,4 @@ export class DashboardPage {
   toTimeline() {
     this.navCtrl.setRoot(TimelinePage);
   }
-
-  lastDate() {
-    let toast = this.toastCtrl.create({
-      message: `Your last assessment was on 11/17/2018`,
-      duration: 2500,
-      position: 'middle'
-    });
-
-    toast.present();
-  }
 }

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -119,15 +119,13 @@ export class LoginPage {
 
   toDashboard() {
     let toast = this.toastCtrl.create({
-      message: "Login successful!",
+      message: "Login successful! Your last assessment was on 11/26/2018.",
       duration: 2500,
-      position: 'middle'
-    });
-  
-    toast.onDidDismiss(() => {
-      this.navCtrl.setRoot(DashboardPage)
+      position: 'middle',
+      cssClass: 'wizardToast'
     });
   
     toast.present();
+    this.navCtrl.setRoot(DashboardPage)
   }
 }

--- a/src/pages/register/register.html
+++ b/src/pages/register/register.html
@@ -296,5 +296,6 @@
         </ion-col>
       </ion-row>
     </ion-grid>
+    <div class="wizardToast"></div>
       
   </ion-content>

--- a/src/pages/register/register.ts
+++ b/src/pages/register/register.ts
@@ -71,16 +71,14 @@ export class RegisterPage {
 
   goWizard() {
     let toast = this.toastCtrl.create({
-      message: 'Welcome to InTransition!',
+      message: 'Thank you for registering. Welcome to InTransition!',
       duration: 2500,
-      position: 'middle'
-    });
-  
-    toast.onDidDismiss(() => {
-      this.navCtrl.setRoot(WizardPage, {registered: this.registerUser})
+      position: 'middle',
+      cssClass: 'wizardToast',
     });
   
     toast.present();
+    this.navCtrl.setRoot(WizardPage, {registered: this.registerUser});
   }
 
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -3,6 +3,8 @@
 
 //ToastController width
 $toast-max-width: 1000px;
+$toast-ios-title-font-size: 25px;
+$toast-ios-title-padding-top: 2rem;
 
 // Font path is used to include ionicons,
 // roboto, and noto sans fonts


### PR DESCRIPTION
**Describe the changes in this Pull Request**
Toast text is a bit bigger. Also, the toasts had to wait 2.5 seconds to dismiss, then the page change triggered. So I changed it so that the toast pops up and the page changes at the same time. Seemed to flow better.