### PR TITLE
Changed toast class name

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -16,7 +16,7 @@
     font-size: 20px;
 }
 
-.wizardToast {
+.toasts {
     text-align: center !important;
   }
 
@@ -34,7 +34,7 @@
         font-size: 25px!important;
     }
 
-    .wizardToast {
+    .toasts {
         text-align: center !important;
       }
 

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -122,7 +122,7 @@ export class LoginPage {
       message: "Login successful! Your last assessment was on 11/26/2018.",
       duration: 2500,
       position: 'middle',
-      cssClass: 'wizardToast'
+      cssClass: 'toasts' // You can find the css class in app.scss
     });
   
     toast.present();

--- a/src/pages/register/register.ts
+++ b/src/pages/register/register.ts
@@ -74,7 +74,7 @@ export class RegisterPage {
       message: 'Thank you for registering. Welcome to InTransition!',
       duration: 2500,
       position: 'middle',
-      cssClass: 'wizardToast',
+      cssClass: 'toasts', // You can find the css class in app.scss
     });
   
     toast.present();


### PR DESCRIPTION
**Describe the changes in this Pull Request**
toast class name was misleading before, saying wizardtoast even though it applied to the toast that popped up on the wizard and the toast that pops up on the dashboard.