### PR TITLE
fixed dashboard days alert

### DIFF
--- a/src/pages/dashboard/dashboard.html
+++ b/src/pages/dashboard/dashboard.html
@@ -36,9 +36,15 @@
     <ion-row>
       <ion-col>
         <ion-card class="sep">
-          <ion-card-header class="headers" text-center>
+          <ion-card-header class="headers" text-center *ngIf="daysTilSep > 0">
             {{daysTilSep}} Days Until Separation!
           </ion-card-header>
+          <ion-card-header class="headers" text-center *ngIf="daysTilSep == 0">
+              Your Separation Date is Today!
+            </ion-card-header>
+            <ion-card-header class="headers" text-center *ngIf="daysTilSep < 0">
+              Your Separation Was {{daysTilSepAbs}} Days Ago!
+              </ion-card-header>
           <ion-card-content id="separationContent">
             You're getting close to your separation day! Are you preparing for the transition? Have you checked the
             timeline for instructions?

--- a/src/pages/dashboard/dashboard.ts
+++ b/src/pages/dashboard/dashboard.ts
@@ -21,6 +21,7 @@ export class DashboardPage {
   name: any
   date: any
   daysTilSep: any
+  daysTilSepAbs: any
 
   constructor(public navCtrl: NavController, 
     public navParams: NavParams,
@@ -44,6 +45,7 @@ export class DashboardPage {
       let sepDate = moment(data.separationDate, "YYYY-MM-DD").toDate().getTime();
       let now = new Date().getTime();
       this.daysTilSep = Math.ceil((sepDate - now)/86400000);
+      this.daysTilSepAbs = Math.abs(this.daysTilSep);
       console.log(this.daysTilSep, this.name)
     })
   }


### PR DESCRIPTION
Before:
Dashboard would display same message for amount of days til separation (if negative it would say "-21 days until separation")

Now:
Dashboard has 3 different messages according to number of days
1. "__ days until separation"
2. "your separation day is today"
3. "your separation date was __ days ago"